### PR TITLE
Fix problem link do screenshot file

### DIFF
--- a/screens.md
+++ b/screens.md
@@ -7,12 +7,12 @@ Here are a few screenshots of Exaile:
 
 ### Exaile 3.4 Beta
 
-[![]({{ "/public/images/exaile-3.4.png" | relative_url }})]({{ "/public/images/exaile-3.4.png" | relative_url }}")
+[![]({{ "/public/images/exaile-3.4.png" | relative_url }})]({{ "/public/images/exaile-3.4.png" | relative_url }} "")
 
 ### Exaile 0.3.0a3 (devel version)
 
-[![]({{ "/public/images/exaile-0.3.0.png" | relative_url }})]({{ "/public/images/exaile-0.3.0.png" | relative_url }} "Random Screenshot")
+[![]({{ "/public/images/exaile-0.3.0.png" | relative_url }})]({{ "/public/images/exaile-0.3.0.png" | relative_url }} "")
 
 ### Exaile 0.2.x
 
-[![]({{ "/public/images/exaile-0.2.png" | relative_url }})]({{ "/public/images/exaile-0.2.png" | relative_url }} "Rating System")
+[![]({{ "/public/images/exaile-0.2.png" | relative_url }})]({{ "/public/images/exaile-0.2.png" | relative_url }} "")


### PR DESCRIPTION
`"` causes the link to point to `https://www.exaile.org/public/images/exaile-3.4.png"` generating 404 on a click.